### PR TITLE
Possibilidade de especificar o formato no modo CLI

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,6 +53,7 @@ cd cli/ && npm install
  - Ajuda: ``node index.js --help``
  - Salvando em arquivo **.mp4**:  ``node index.js --url "https://www.youtube.com/watch?v=qrMwxe2ya5E" -o video.mp4``
  - Salvando com **stdout**: ``node index.js --url "https://www.youtube.com/watch?v=qrMwxe2ya5E" > video.mp4``
+ - Especificando formato: ``node index.js --url "https://www.youtube.com/watch?v=qrMwxe2ya5E" --format mp4``
  
 ### License
 ----

--- a/cli/index.js
+++ b/cli/index.js
@@ -24,8 +24,8 @@ if (ytdl.validateURL(args.url)) {
   }
 
   const stream = ytdl(args.url, {
-    filter: format => format.container === 'mp4',
-    format: 'mp4',
+    filter: format => format.container === args.format,
+    format: args.format,
   })
 
   stream.pipe(output())

--- a/cli/input.js
+++ b/cli/input.js
@@ -1,5 +1,7 @@
 const path = require('path');
 
+const formats = ['3gp', 'aac', 'flv', 'm4a', 'mp3', 'mp4', 'ogg', 'wav', 'webm']
+
 function createYargsTemplate(yargs) {
   return yargs
     .help()
@@ -12,7 +14,14 @@ function createYargsTemplate(yargs) {
       coerce: (it) => it === null ? it : path.resolve(it),
       description: 'The file to save the video\n If default the file contents will be printed to stdout',
       default: null
-    })
+    }).option('format', {
+      alias: ['f'],
+      type: 'string',
+      choices: formats,
+      coerce: (it) => it.toLowerCase(),
+      description: 'The format to save the video',
+      default: 'mp4'
+  })
 }
 
 module.exports = {


### PR DESCRIPTION
Adicionado a possibilidade de especificar o formato no modo CLI através do argumento ``--format``

Ainda não consegui achar uma forma de cancelar o procedimento quando o formado especificado não estiver disponivel para tal vídeo